### PR TITLE
Make loading of test/test_helper.exs optional or failure tolerant

### DIFF
--- a/lib/test_iex.ex
+++ b/lib/test_iex.ex
@@ -1,12 +1,12 @@
 defmodule TestIex do
-  @moduledoc"""
+  @moduledoc """
   A utility module that helps you iterate faster on unit tests.
 
   This module lets execute specific tests from within a running iex shell to
   avoid needing to start and stop the whole application every time.
   """
 
-  @doc"""
+  @doc """
   Starts the testing context.
 
   ## Examples
@@ -14,11 +14,13 @@ defmodule TestIex do
   """
   def start_testing() do
     ExUnit.start()
+
     Code.eval_file("test/test_helper.exs", File.cwd!())
+
     :ok
   end
 
-  @doc"""
+  @doc """
   Loads or reloads testing helpers
 
   ## Examples
@@ -28,7 +30,7 @@ defmodule TestIex do
     Code.eval_file(file_name, File.cwd!())
   end
 
-  @doc"""
+  @doc """
   Runs a single test, a test file, or multiple test files
 
   ## Example: Run a single test
@@ -41,6 +43,7 @@ defmodule TestIex do
       iex> TestIex.test(["./path/test/file/test_file_test.exs", "./path/test/file/test_file_2_test.exs"])
   """
   def test(path, line \\ nil)
+
   def test(path, line) when is_binary(path) do
     if line do
       ExUnit.configure(exclude: [:test], include: [line: line])
@@ -58,6 +61,7 @@ defmodule TestIex do
 
     ExUnit.run()
   end
+
   def test(paths, _line) when is_list(paths) do
     ExUnit.configure(exclude: [], include: [])
 
@@ -76,6 +80,6 @@ defmodule TestIex do
     System.version()
     |> String.split(".")
     |> Enum.at(1)
-    |> String.to_integer >= 6
+    |> String.to_integer() >= 6
   end
 end

--- a/lib/test_iex.ex
+++ b/lib/test_iex.ex
@@ -15,7 +15,9 @@ defmodule TestIex do
   def start_testing() do
     ExUnit.start()
 
-    Code.eval_file("test/test_helper.exs", File.cwd!())
+    if File.exists?("test/test_helper.exs") do
+      Code.eval_file("test/test_helper.exs", File.cwd!())
+    end
 
     :ok
   end


### PR DESCRIPTION
Hello,

I have a project where the test files are placed in the same directory as the files they test.
Thus there are no tests in the default `test` folder and also no `test/test_helper.exs` file.

This PR loads the default test_helper only if it exists.